### PR TITLE
Use descending ecstasy in hotel_search

### DIFF
--- a/hotel_search/scraperapi_test.py
+++ b/hotel_search/scraperapi_test.py
@@ -27,7 +27,7 @@ def test_hotel_search():
             expected, count
         )
 
-    sorted_results = sorted(results, key=lambda r: r["ecstasy"])
+    sorted_results = sorted(results, key=lambda r: r["ecstasy"], reverse=True)
     assert results == sorted_results, "Results aren't sorted properly!"
 
     took = resp.elapsed.total_seconds()

--- a/hotel_search/scrapers/common.py
+++ b/hotel_search/scrapers/common.py
@@ -15,7 +15,7 @@ class Scraper(object):
         yield gen.sleep(2)
 
         self.load_fake_results(xrange(1, 20, self.step))
-        self.results.sort(key=lambda r: r['ecstasy'])
+        self.results.sort(key=lambda r: r['ecstasy'], reverse=True)
 
         raise gen.Return(self.results)
 


### PR DESCRIPTION
The most recent version of hotel_search delivered results in ascending ecstasy, and then expected the candidates' results to be ascending. This patch changes both of those sort orders to descending.